### PR TITLE
Update Field Width Constant

### DIFF
--- a/choreolib/src/main/java/com/choreo/lib/ChoreoTrajectoryState.java
+++ b/choreolib/src/main/java/com/choreo/lib/ChoreoTrajectoryState.java
@@ -10,7 +10,7 @@ import edu.wpi.first.math.kinematics.ChassisSpeeds;
 
 /** A single robot state in a ChoreoTrajectory. */
 public class ChoreoTrajectoryState implements Interpolatable<ChoreoTrajectoryState> {
-  private static final double FIELD_WIDTH_METERS = 16.55445;
+  private static final double FIELD_WIDTH_METERS = 16.5410515;
 
   /** The timestamp of this state, relative to the beginning of the trajectory. */
   public final double timestamp;


### PR DESCRIPTION
Taken directly from cad at https://cad.onshape.com/documents/dcbe49ce579f6342435bc298/w/b93673f5b2ec9c9bdcfec487/e/6ecb2d6b7590f4d1c820d5e3 Is there a possibility that because the link above is the optimized version the old number was gotten from the original import and thus this change is wrong?